### PR TITLE
Cherry-pick updates from upstream to address fastmem issues

### DIFF
--- a/src/common/crash_handler.cpp
+++ b/src/common/crash_handler.cpp
@@ -77,7 +77,7 @@ static std::wstring s_write_directory;
 static PVOID s_veh_handle = nullptr;
 static bool s_in_crash_handler = false;
 
-static LONG ExceptionHandler(struct _EXCEPTION_POINTERS exi)
+static LONG NTAPI ExceptionHandler(PEXCEPTION_POINTERS exi)
 {
   if (s_in_crash_handler)
     return EXCEPTION_CONTINUE_SEARCH;

--- a/src/common/memory_arena.cpp
+++ b/src/common/memory_arena.cpp
@@ -213,6 +213,15 @@ std::optional<MemoryArena::View> MemoryArena::CreateView(size_t offset, size_t s
   return View(this, base_pointer, offset, size, writable);
 }
 
+std::optional<MemoryArena::View> MemoryArena::CreateReservedView(size_t size, void* fixed_address /*= nullptr*/)
+{
+  void* base_pointer = CreateReservedPtr(size, fixed_address);
+  if (!base_pointer)
+    return std::nullopt;
+
+  return View(this, base_pointer, View::RESERVED_REGION_OFFSET, size, false);
+}
+
 void* MemoryArena::CreateViewPtr(size_t offset, size_t size, bool writable, bool executable,
                                  void* fixed_address /*= nullptr*/)
 {
@@ -276,6 +285,53 @@ bool MemoryArena::ReleaseViewPtr(void* address, size_t size)
   return true;
 }
 
+void* MemoryArena::CreateReservedPtr(size_t size, void* fixed_address /*= nullptr*/)
+{
+  void* base_pointer;
+#if defined(WIN32)
+  base_pointer = VirtualAlloc(fixed_address, size, MEM_RESERVE, PAGE_NOACCESS);
+#elif defined(__linux__)
+  const int flags =
+    (fixed_address != nullptr) ? (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED) : (MAP_PRIVATE | MAP_ANONYMOUS);
+  base_pointer = mmap64(fixed_address, size, PROT_NONE, flags, -1, 0);
+  if (base_pointer == reinterpret_cast<void*>(-1))
+    return nullptr;
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+  const int flags =
+    (fixed_address != nullptr) ? (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED) : (MAP_PRIVATE | MAP_ANONYMOUS);
+  base_pointer = mmap(fixed_address, size, prot, PROT_NONE, -1, 0);
+  if (base_pointer == reinterpret_cast<void*>(-1))
+    return nullptr;
+#else
+  return nullptr;
+#endif
+
+  m_num_views.fetch_add(1);
+  return base_pointer;
+}
+
+bool MemoryArena::ReleaseReservedPtr(void* address, size_t size)
+{
+  bool result;
+#if defined(WIN32)
+  result = static_cast<bool>(VirtualFree(address, 0, MEM_RELEASE));
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+  result = (munmap(address, size) >= 0);
+#else
+  result = false;
+#endif
+
+  if (!result)
+  {
+    Log_ErrorPrintf("Failed to release previously-created view at %p", address);
+    return false;
+  }
+
+  const size_t prev_count = m_num_views.fetch_sub(1);
+  Assert(prev_count > 0);
+  return true;
+}
+
 bool MemoryArena::SetPageProtection(void* address, size_t length, bool readable, bool writable, bool executable)
 {
 #if defined(WIN32)
@@ -315,10 +371,18 @@ MemoryArena::View::~View()
 {
   if (m_parent)
   {
-    if (m_writable && !m_parent->FlushViewPtr(m_base_pointer, m_mapping_size))
-      Panic("Failed to flush previously-created view");
-    if (!m_parent->ReleaseViewPtr(m_base_pointer, m_mapping_size))
-      Panic("Failed to unmap previously-created view");
+    if (m_arena_offset != RESERVED_REGION_OFFSET)
+    {
+      if (m_writable && !m_parent->FlushViewPtr(m_base_pointer, m_mapping_size))
+        Panic("Failed to flush previously-created view");
+      if (!m_parent->ReleaseViewPtr(m_base_pointer, m_mapping_size))
+        Panic("Failed to unmap previously-created view");
+    }
+    else
+    {
+      if (!m_parent->ReleaseReservedPtr(m_base_pointer, m_mapping_size))
+        Panic("Failed to release previously-created view");
+    }
   }
 }
 } // namespace Common

--- a/src/common/memory_arena.h
+++ b/src/common/memory_arena.h
@@ -10,6 +10,11 @@ public:
   class View
   {
   public:
+    enum : size_t
+    {
+      RESERVED_REGION_OFFSET = static_cast<size_t>(-1)
+    };
+
     View(MemoryArena* parent, void* base_pointer, size_t arena_offset, size_t mapping_size, bool writable);
     View(View&& view);
     ~View();
@@ -39,9 +44,14 @@ public:
   std::optional<View> CreateView(size_t offset, size_t size, bool writable, bool executable,
                                  void* fixed_address = nullptr);
 
+  std::optional<View> CreateReservedView(size_t size,  void* fixed_address = nullptr);
+
   void* CreateViewPtr(size_t offset, size_t size, bool writable, bool executable, void* fixed_address = nullptr);
   bool FlushViewPtr(void* address, size_t size);
   bool ReleaseViewPtr(void* address, size_t size);
+
+  void* CreateReservedPtr(size_t size, void* fixed_address = nullptr);
+  bool ReleaseReservedPtr(void* address, size_t size);
 
   static bool SetPageProtection(void* address, size_t length, bool readable, bool writable, bool executable);
 

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -307,7 +307,14 @@ CPUFastmemMode GetFastmemMode()
 
 u8* GetFastmemBase()
 {
-  return m_fastmem_base;
+#ifdef WITH_MMAP_FASTMEM
+  if (m_fastmem_mode == CPUFastmemMode::MMap)
+    return m_fastmem_base;
+#endif
+  if (m_fastmem_mode == CPUFastmemMode::LUT)
+    return reinterpret_cast<u8*>(m_fastmem_lut);
+
+  return nullptr;
 }
 
 void UpdateFastmemViews(CPUFastmemMode mode)
@@ -346,7 +353,6 @@ void UpdateFastmemViews(CPUFastmemMode mode)
       }
 
       Log_InfoPrintf("Fastmem base: %p", m_fastmem_base);
-      CPU::g_state.fastmem_base = m_fastmem_base;
     }
 
     auto MapRAM = [](u32 base_address) {
@@ -423,7 +429,6 @@ void UpdateFastmemViews(CPUFastmemMode mode)
     Assert(m_fastmem_lut);
 
     Log_InfoPrintf("Fastmem base (software): %p", m_fastmem_lut);
-    CPU::g_state.fastmem_base = reinterpret_cast<u8*>(m_fastmem_lut);
   }
 
   auto MapRAM = [](u32 base_address) {

--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -100,7 +100,8 @@ void Reset();
 bool DoState(StateWrapper& sw);
 
 CPUFastmemMode GetFastmemMode();
-void UpdateFastmemViews(CPUFastmemMode mode, bool isolate_cache);
+u8* GetFastmemBase();
+void UpdateFastmemViews(CPUFastmemMode mode);
 bool CanUseFastmemForAddress(VirtualMemoryAddress address);
 
 void SetExpansionROM(std::vector<u8> data);

--- a/src/core/cpu_code_cache.cpp
+++ b/src/core/cpu_code_cache.cpp
@@ -785,6 +785,7 @@ bool InitializeFastmem()
   }
 
   Bus::UpdateFastmemViews(mode);
+  CPU::UpdateFastmemBase();
   return true;
 }
 
@@ -792,6 +793,7 @@ void ShutdownFastmem()
 {
   Common::PageFaultHandler::RemoveHandler(&s_host_code_map);
   Bus::UpdateFastmemViews(CPUFastmemMode::Disabled);
+  CPU::UpdateFastmemBase();
 }
 
 #ifdef WITH_MMAP_FASTMEM

--- a/src/core/cpu_code_cache.cpp
+++ b/src/core/cpu_code_cache.cpp
@@ -784,14 +784,14 @@ bool InitializeFastmem()
     return false;
   }
 
-  Bus::UpdateFastmemViews(mode, g_state.cop0_regs.sr.Isc);
+  Bus::UpdateFastmemViews(mode);
   return true;
 }
 
 void ShutdownFastmem()
 {
   Common::PageFaultHandler::RemoveHandler(&s_host_code_map);
-  Bus::UpdateFastmemViews(CPUFastmemMode::Disabled, false);
+  Bus::UpdateFastmemViews(CPUFastmemMode::Disabled);
 }
 
 #ifdef WITH_MMAP_FASTMEM

--- a/src/core/cpu_core.cpp
+++ b/src/core/cpu_core.cpp
@@ -99,6 +99,8 @@ void Initialize()
   s_last_breakpoint_check_pc = INVALID_BREAKPOINT_PC;
   s_single_step = false;
 
+  UpdateFastmemBase();
+
   GTE::Initialize();
 
   if (g_settings.gpu_pgxp_enable)
@@ -131,6 +133,7 @@ void Reset()
   g_state.cop0_regs.cause.bits = 0;
 
   ClearICache();
+  UpdateFastmemBase();
 
   GTE::Reset();
 
@@ -193,6 +196,14 @@ bool DoState(StateWrapper& sw)
   }
 
   return !sw.HasError();
+}
+
+void UpdateFastmemBase()
+{
+  if (g_state.cop0_regs.sr.Isc)
+    g_state.fastmem_base = nullptr;
+  else
+    g_state.fastmem_base = Bus::GetFastmemBase();
 }
 
 ALWAYS_INLINE_RELEASE void SetPC(u32 new_pc)
@@ -1971,14 +1982,6 @@ bool InterpretInstructionPGXP()
 {
   ExecuteInstruction<PGXPMode::Memory>();
   return g_state.exception_raised;
-}
-
-void UpdateFastmemMapping()
-{
-  if (g_state.cop0_regs.sr.Isc)
-    g_state.fastmem_base = nullptr;
-  else
-    g_state.fastmem_base = Bus::GetFastmemBase();
 }
 
 } // namespace Recompiler::Thunks

--- a/src/core/cpu_core.cpp
+++ b/src/core/cpu_core.cpp
@@ -1975,7 +1975,10 @@ bool InterpretInstructionPGXP()
 
 void UpdateFastmemMapping()
 {
-  Bus::UpdateFastmemViews(Bus::GetFastmemMode(), g_state.cop0_regs.sr.Isc);
+  if (g_state.cop0_regs.sr.Isc)
+    g_state.fastmem_base = nullptr;
+  else
+    g_state.fastmem_base = Bus::GetFastmemBase();
 }
 
 } // namespace Recompiler::Thunks

--- a/src/core/cpu_core.h
+++ b/src/core/cpu_core.h
@@ -94,6 +94,7 @@ void Shutdown();
 void Reset();
 bool DoState(StateWrapper& sw);
 void ClearICache();
+void UpdateFastmemBase();
 
 /// Executes interpreter loop.
 void Execute();

--- a/src/core/cpu_recompiler_code_generator.cpp
+++ b/src/core/cpu_recompiler_code_generator.cpp
@@ -2476,6 +2476,7 @@ bool CodeGenerator::Compile_cop0(const CodeBlockInstruction& cbi)
               EmitBranchIfBitClear(old_value.host_reg, RegSize_32, 16, &skip_fastmem_update);
               m_register_cache.InhibitAllocation();
               EmitFunctionCall(nullptr, &Thunks::UpdateFastmemMapping, m_register_cache.GetCPUPtr());
+              EmitUpdateMembasePointer();
               EmitBindLabel(&skip_fastmem_update);
               m_register_cache.UninhibitAllocation();
             }

--- a/src/core/cpu_recompiler_code_generator.h
+++ b/src/core/cpu_recompiler_code_generator.h
@@ -93,6 +93,7 @@ public:
   void EmitStoreGuestMemoryFastmem(const CodeBlockInstruction& cbi, const Value& address, const Value& value);
   void EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi, const Value& address, const Value& value,
                                    bool in_far_code);
+  void EmitUpdateMembasePointer();
 
   // Unconditional branch to pointer. May allocate a scratch register.
   void EmitBranch(const void* address, bool allow_scratch = true);

--- a/src/core/cpu_recompiler_code_generator.h
+++ b/src/core/cpu_recompiler_code_generator.h
@@ -93,7 +93,7 @@ public:
   void EmitStoreGuestMemoryFastmem(const CodeBlockInstruction& cbi, const Value& address, const Value& value);
   void EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi, const Value& address, const Value& value,
                                    bool in_far_code);
-  void EmitUpdateMembasePointer();
+  void EmitUpdateFastmemBase();
 
   // Unconditional branch to pointer. May allocate a scratch register.
   void EmitBranch(const void* address, bool allow_scratch = true);
@@ -264,6 +264,7 @@ private:
   {
     std::array<SpeculativeValue, static_cast<u8>(Reg::count)> regs;
     std::unordered_map<PhysicalMemoryAddress, SpeculativeValue> memory;
+    SpeculativeValue cop0_sr;
   };
 
   void InitSpeculativeRegs();
@@ -272,6 +273,7 @@ private:
   void SpeculativeWriteReg(Reg reg, SpeculativeValue value);
   SpeculativeValue SpeculativeReadMemory(u32 address);
   void SpeculativeWriteMemory(VirtualMemoryAddress address, SpeculativeValue value);
+  bool SpeculativeIsCacheIsolated();
 
   SpeculativeConstants m_speculative_constants;
 };

--- a/src/core/cpu_recompiler_code_generator_aarch32.cpp
+++ b/src/core/cpu_recompiler_code_generator_aarch32.cpp
@@ -1170,6 +1170,22 @@ Value CodeGenerator::GetFastmemStoreBase()
   return val;
 }
 
+void CodeGenerator::EmitUpdateMembasePointer()
+{
+  if (m_fastmem_load_base_in_register)
+  {
+    Value val = Value::FromHostReg(&m_register_cache, RARG4, RegSize_32);
+    m_emit->ldr(GetHostReg32(val), a32::MemOperand(GetCPUPtrReg(), offsetof(CPU::State, fastmem_base)));
+  }
+
+  if (m_fastmem_store_base_in_register)
+  {
+    Value val = Value::FromHostReg(&m_register_cache, RARG3, RegSize_32);
+    m_emit->ldr(GetHostReg32(val), a32::MemOperand(GetCPUPtrReg(), offsetof(CPU::State, fastmem_base)));
+    m_emit->add(GetHostReg32(val), GetHostReg32(val), sizeof(u32*) * Bus::FASTMEM_LUT_NUM_PAGES);
+  }
+}
+
 void CodeGenerator::EmitLoadGuestRAMFastmem(const Value& address, RegSize size, Value& result)
 {
   Value fastmem_base = GetFastmemLoadBase();

--- a/src/core/cpu_recompiler_code_generator_aarch32.cpp
+++ b/src/core/cpu_recompiler_code_generator_aarch32.cpp
@@ -1170,7 +1170,7 @@ Value CodeGenerator::GetFastmemStoreBase()
   return val;
 }
 
-void CodeGenerator::EmitUpdateMembasePointer()
+void CodeGenerator::EmitUpdateFastmemBase()
 {
   if (m_fastmem_load_base_in_register)
   {

--- a/src/core/cpu_recompiler_code_generator_aarch64.cpp
+++ b/src/core/cpu_recompiler_code_generator_aarch64.cpp
@@ -1728,6 +1728,11 @@ void CodeGenerator::EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi,
   }
 }
 
+void CodeGenerator::EmitUpdateMembasePointer()
+{
+  m_emit->Ldr(GetFastmemBasePtrReg(), a64::MemOperand(GetCPUPtrReg(), offsetof(State, fastmem_base)));
+}
+
 bool CodeGenerator::BackpatchLoadStore(const LoadStoreBackpatchInfo& lbi)
 {
   Log_DevPrintf("Backpatching %p (guest PC 0x%08X) to slowmem at %p", lbi.host_pc, lbi.guest_pc, lbi.host_slowmem_pc);

--- a/src/core/cpu_recompiler_code_generator_aarch64.cpp
+++ b/src/core/cpu_recompiler_code_generator_aarch64.cpp
@@ -1728,7 +1728,7 @@ void CodeGenerator::EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi,
   }
 }
 
-void CodeGenerator::EmitUpdateMembasePointer()
+void CodeGenerator::EmitUpdateFastmemBase()
 {
   m_emit->Ldr(GetFastmemBasePtrReg(), a64::MemOperand(GetCPUPtrReg(), offsetof(State, fastmem_base)));
 }

--- a/src/core/cpu_recompiler_code_generator_x64.cpp
+++ b/src/core/cpu_recompiler_code_generator_x64.cpp
@@ -2313,6 +2313,11 @@ void CodeGenerator::EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi,
   }
 }
 
+void CodeGenerator::EmitUpdateMembasePointer()
+{
+  m_emit->mov(GetFastmemBasePtrReg(), m_emit->qword[GetCPUPtrReg() + offsetof(CPU::State, fastmem_base)]);
+}
+
 bool CodeGenerator::BackpatchLoadStore(const LoadStoreBackpatchInfo& lbi)
 {
   Log_DevPrintf("Backpatching %p (guest PC 0x%08X) to slowmem", lbi.host_pc, lbi.guest_pc);

--- a/src/core/cpu_recompiler_code_generator_x64.cpp
+++ b/src/core/cpu_recompiler_code_generator_x64.cpp
@@ -2313,7 +2313,7 @@ void CodeGenerator::EmitStoreGuestMemorySlowmem(const CodeBlockInstruction& cbi,
   }
 }
 
-void CodeGenerator::EmitUpdateMembasePointer()
+void CodeGenerator::EmitUpdateFastmemBase()
 {
   m_emit->mov(GetFastmemBasePtrReg(), m_emit->qword[GetCPUPtrReg() + offsetof(CPU::State, fastmem_base)]);
 }

--- a/src/core/cpu_recompiler_thunks.h
+++ b/src/core/cpu_recompiler_thunks.h
@@ -32,8 +32,6 @@ void UncheckedWriteMemoryByte(u32 address, u8 value);
 void UncheckedWriteMemoryHalfWord(u32 address, u16 value);
 void UncheckedWriteMemoryWord(u32 address, u32 value);
 
-void UpdateFastmemMapping();
-
 } // namespace Recompiler::Thunks
 
 } // namespace CPU

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -805,9 +805,6 @@ void HostInterface::CheckForSettingsChanges(const Settings& old_settings)
         g_settings.rewind_enable != old_settings.rewind_enable ||
         g_settings.runahead_frames != old_settings.runahead_frames)
     {
-      if (g_settings.IsUsingCodeCache())
-        CPU::CodeCache::Reinitialize();
-
       g_gpu->UpdateSettings();
     }
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -689,9 +689,6 @@ bool RecreateGPU(GPURenderer renderer, bool update_display /* = true*/)
     return false;
   }
 
-  // reinitialize the code cache because the address space could change
-  CPU::CodeCache::Reinitialize();
-
   if (state_valid)
   {
     state_stream->SeekAbsolute(0);
@@ -1994,10 +1991,6 @@ bool InsertMedia(const char* path)
     UpdateMemoryCards();
   }
 
-  // reinitialize recompiler, because especially with preloading this might overlap the fastmem area
-  if (g_settings.IsUsingCodeCache())
-    CPU::CodeCache::Reinitialize();
-
   ClearMemorySaveStates();
   return true;
 }
@@ -2145,6 +2138,7 @@ bool ReplaceMediaPathFromPlaylist(u32 index, const std::string_view& path)
     s_media_playlist[index] = path;
   }
 
+  ClearMemorySaveStates();
   return true;
 }
 


### PR DESCRIPTION
As per @kivutar's suggestion, this PR backports two recent commits from the upstream repository that may be helpful for addressing fastmem issues.

See issue https://github.com/libretro/duckstation/issues/30 as reference.

I tested this on Windows. The libretro core compiles fine and so far seems to work without any visible issue.